### PR TITLE
Install packages on Arch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "shaper"
 path = "src/bin/main.rs"
 
 [dependencies]
-clap = "2.2.2"
+clap = "2.2.3"
 
 [features]
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,6 +5,7 @@ extern crate clap;
 //Shaper Imports
 use shaper::su;
 use shaper::distro::common::{Distro,which_distro};
+use shaper::distro::arch;
 
 //Clap Imports
 use clap::{App, Arg};
@@ -24,6 +25,11 @@ fn main() {
                     .version("0.1.0")
                     .author("Michael Gattozzi <mgattozzi@gmail.com>")
                     .about("Unix Platform Agnostic Installer")
+                    .arg(Arg::with_name("install")
+                         .short("i")
+                         .takes_value(true)
+                         .multiple(true)
+                         .help("Install the given programs"))
                     .arg(Arg::with_name("debug")
                          .short("d")
                          .long("debug")
@@ -34,15 +40,17 @@ fn main() {
                          .help("Make output more verbose"))
                     .get_matches();
 
-    //Set Argument Flag variables
+    //Create Argument Flag variables
     let mut debug = false;
     let mut verbose = false;
 
-    if let Some(d) = args.value_of("debug") {
+    //Toggle debug
+    if args.is_present("debug") {
         debug = true;
     }
 
-    if let Some(v) = args.value_of("verbose") {
+    //Toggle verbos
+    if args.is_present("verbose") {
         verbose = true;
     }
 
@@ -53,8 +61,18 @@ fn main() {
         exit(0);
     }
 
+    //Prepare parse arguments of what to install
+    let mut packages: Vec<&str> = Vec::new();
+    if let Some(p) = args.values_of("install") {
+        for i in p {
+            packages.push(i);
+        }
+    }
+
     match opt_dist.expect("None found, Distro was not handled") {
-        Distro::Arch    => println!("Arch Linux"),
+        Distro::Arch    => {
+            arch::pac_install(packages);
+        },
         Distro::Ubuntu  => println!("Ubuntu"),
         Distro::Mint    => println!("Mint"),
         Distro::Debian  => println!("Debian"),

--- a/src/shaper/distro/arch.rs
+++ b/src/shaper/distro/arch.rs
@@ -1,0 +1,12 @@
+use std::process::{Command};
+pub fn pac_install(packages: Vec<&str>) {
+    let mut child = match Command::new("pacman")
+            .arg("-S")
+            .args(packages.as_slice())
+            .spawn()
+    {
+        Ok(child) => child,
+        Err(e)    => panic!("Failed to execute child: {}",e),
+    };
+    let _unused = child.wait();
+}


### PR DESCRIPTION
Installs pacakges on Arch Linux passed in from command line
Usage of the -i flag and subsequent arguments will install
packages with pacman. No refreshing.
This is a one to one conversion however so no mapping is
implemented yet.